### PR TITLE
Feature/image feed/loader cache decorators

### DIFF
--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		C59A89CA28FAC12A00DFD3F3 /* FeedImageDataLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59A89C928FAC12A00DFD3F3 /* FeedImageDataLoaderCacheDecoratorTests.swift */; };
 		C59A89CC28FACD8E00DFD3F3 /* FeedImageDataLoaderSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59A89CB28FACD8E00DFD3F3 /* FeedImageDataLoaderSpy.swift */; };
 		C59A89CE28FACDF000DFD3F3 /* XCTestCase+FeedImageDataLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59A89CD28FACDF000DFD3F3 /* XCTestCase+FeedImageDataLoader.swift */; };
+		C59A89D228FAD28D00DFD3F3 /* FeedImageDataLoaderCacheDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59A89D128FAD28D00DFD3F3 /* FeedImageDataLoaderCacheDecorator.swift */; };
 		C5B2216C28F5D95600FC61CF /* EssentialFeed.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5B2216A28F5D95600FC61CF /* EssentialFeed.framework */; };
 		C5B2216D28F5D95600FC61CF /* EssentialFeed.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C5B2216A28F5D95600FC61CF /* EssentialFeed.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		C5B2216E28F5D95600FC61CF /* EssentialFeediOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5B2216B28F5D95600FC61CF /* EssentialFeediOS.framework */; };
@@ -86,6 +87,7 @@
 		C59A89C928FAC12A00DFD3F3 /* FeedImageDataLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
 		C59A89CB28FACD8E00DFD3F3 /* FeedImageDataLoaderSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderSpy.swift; sourceTree = "<group>"; };
 		C59A89CD28FACDF000DFD3F3 /* XCTestCase+FeedImageDataLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FeedImageDataLoader.swift"; sourceTree = "<group>"; };
+		C59A89D128FAD28D00DFD3F3 /* FeedImageDataLoaderCacheDecorator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderCacheDecorator.swift; sourceTree = "<group>"; };
 		C5B2216A28F5D95600FC61CF /* EssentialFeed.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = EssentialFeed.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C5B2216B28F5D95600FC61CF /* EssentialFeediOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = EssentialFeediOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C5E6070628F9C8D90062DFEE /* FeedLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
@@ -166,6 +168,7 @@
 				C5296BDB28F9195C00CA7381 /* FeedLoaderWithFallbackComposite.swift */,
 				C5296BDF28F939FB00CA7381 /* FeedImageDataLoaderWithFallbackComposite.swift */,
 				C59A89C728FABBAB00DFD3F3 /* FeedLoaderCacheDecorator.swift */,
+				C59A89D128FAD28D00DFD3F3 /* FeedImageDataLoaderCacheDecorator.swift */,
 			);
 			path = EssentialApp;
 			sourceTree = "<group>";
@@ -331,6 +334,7 @@
 				C59A89C828FABBAB00DFD3F3 /* FeedLoaderCacheDecorator.swift in Sources */,
 				C539527928F5D6D500094060 /* SceneDelegate.swift in Sources */,
 				C5296BE028F939FB00CA7381 /* FeedImageDataLoaderWithFallbackComposite.swift in Sources */,
+				C59A89D228FAD28D00DFD3F3 /* FeedImageDataLoaderCacheDecorator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		C5B2216E28F5D95600FC61CF /* EssentialFeediOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5B2216B28F5D95600FC61CF /* EssentialFeediOS.framework */; };
 		C5B2216F28F5D95600FC61CF /* EssentialFeediOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C5B2216B28F5D95600FC61CF /* EssentialFeediOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		C5E6070728F9C8D90062DFEE /* FeedLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5E6070628F9C8D90062DFEE /* FeedLoaderCacheDecoratorTests.swift */; };
+		C5E6070928F9CACD0062DFEE /* FeedLoaderStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5E6070828F9CACD0062DFEE /* FeedLoaderStub.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -79,6 +80,7 @@
 		C5B2216A28F5D95600FC61CF /* EssentialFeed.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = EssentialFeed.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C5B2216B28F5D95600FC61CF /* EssentialFeediOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = EssentialFeediOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C5E6070628F9C8D90062DFEE /* FeedLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
+		C5E6070828F9CACD0062DFEE /* FeedLoaderStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderStub.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -113,6 +115,7 @@
 			children = (
 				C5296BE228F93A5C00CA7381 /* XCTestCase+MemoryLeakTracking.swift */,
 				C5296BE428F93A9C00CA7381 /* SharedTestHelpers.swift */,
+				C5E6070828F9CACD0062DFEE /* FeedLoaderStub.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -323,6 +326,7 @@
 				C5E6070728F9C8D90062DFEE /* FeedLoaderCacheDecoratorTests.swift in Sources */,
 				C5296BDE28F91A8D00CA7381 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */,
 				C50D2F4328F8805F00ED7ADF /* FeedLoaderWithFallbackCompositeTests.swift in Sources */,
+				C5E6070928F9CACD0062DFEE /* FeedLoaderStub.swift in Sources */,
 				C5296BE328F93A5C00CA7381 /* XCTestCase+MemoryLeakTracking.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		C539528328F5D6D500094060 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C539528128F5D6D500094060 /* LaunchScreen.storyboard */; };
 		C59A89C828FABBAB00DFD3F3 /* FeedLoaderCacheDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59A89C728FABBAB00DFD3F3 /* FeedLoaderCacheDecorator.swift */; };
 		C59A89CA28FAC12A00DFD3F3 /* FeedImageDataLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59A89C928FAC12A00DFD3F3 /* FeedImageDataLoaderCacheDecoratorTests.swift */; };
+		C59A89CC28FACD8E00DFD3F3 /* FeedImageDataLoaderSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59A89CB28FACD8E00DFD3F3 /* FeedImageDataLoaderSpy.swift */; };
 		C5B2216C28F5D95600FC61CF /* EssentialFeed.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5B2216A28F5D95600FC61CF /* EssentialFeed.framework */; };
 		C5B2216D28F5D95600FC61CF /* EssentialFeed.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C5B2216A28F5D95600FC61CF /* EssentialFeed.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		C5B2216E28F5D95600FC61CF /* EssentialFeediOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5B2216B28F5D95600FC61CF /* EssentialFeediOS.framework */; };
@@ -82,6 +83,7 @@
 		C539529328F5D6D500094060 /* EssentialAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = EssentialAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C59A89C728FABBAB00DFD3F3 /* FeedLoaderCacheDecorator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecorator.swift; sourceTree = "<group>"; };
 		C59A89C928FAC12A00DFD3F3 /* FeedImageDataLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
+		C59A89CB28FACD8E00DFD3F3 /* FeedImageDataLoaderSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderSpy.swift; sourceTree = "<group>"; };
 		C5B2216A28F5D95600FC61CF /* EssentialFeed.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = EssentialFeed.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C5B2216B28F5D95600FC61CF /* EssentialFeediOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = EssentialFeediOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C5E6070628F9C8D90062DFEE /* FeedLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
@@ -123,6 +125,7 @@
 				C5296BE428F93A9C00CA7381 /* SharedTestHelpers.swift */,
 				C5E6070828F9CACD0062DFEE /* FeedLoaderStub.swift */,
 				C5E6070A28F9D2770062DFEE /* XCTestCase+FeedLoader.swift */,
+				C59A89CB28FACD8E00DFD3F3 /* FeedImageDataLoaderSpy.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -336,6 +339,7 @@
 				C59A89CA28FAC12A00DFD3F3 /* FeedImageDataLoaderCacheDecoratorTests.swift in Sources */,
 				C5E6070B28F9D2770062DFEE /* XCTestCase+FeedLoader.swift in Sources */,
 				C5E6070728F9C8D90062DFEE /* FeedLoaderCacheDecoratorTests.swift in Sources */,
+				C59A89CC28FACD8E00DFD3F3 /* FeedImageDataLoaderSpy.swift in Sources */,
 				C5296BDE28F91A8D00CA7381 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */,
 				C50D2F4328F8805F00ED7ADF /* FeedLoaderWithFallbackCompositeTests.swift in Sources */,
 				C5E6070928F9CACD0062DFEE /* FeedLoaderStub.swift in Sources */,

--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		C539528028F5D6D500094060 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C539527F28F5D6D500094060 /* Assets.xcassets */; };
 		C539528328F5D6D500094060 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C539528128F5D6D500094060 /* LaunchScreen.storyboard */; };
 		C59A89C828FABBAB00DFD3F3 /* FeedLoaderCacheDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59A89C728FABBAB00DFD3F3 /* FeedLoaderCacheDecorator.swift */; };
+		C59A89CA28FAC12A00DFD3F3 /* FeedImageDataLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59A89C928FAC12A00DFD3F3 /* FeedImageDataLoaderCacheDecoratorTests.swift */; };
 		C5B2216C28F5D95600FC61CF /* EssentialFeed.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5B2216A28F5D95600FC61CF /* EssentialFeed.framework */; };
 		C5B2216D28F5D95600FC61CF /* EssentialFeed.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C5B2216A28F5D95600FC61CF /* EssentialFeed.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		C5B2216E28F5D95600FC61CF /* EssentialFeediOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5B2216B28F5D95600FC61CF /* EssentialFeediOS.framework */; };
@@ -80,6 +81,7 @@
 		C539528928F5D6D500094060 /* EssentialAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = EssentialAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C539529328F5D6D500094060 /* EssentialAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = EssentialAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C59A89C728FABBAB00DFD3F3 /* FeedLoaderCacheDecorator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecorator.swift; sourceTree = "<group>"; };
+		C59A89C928FAC12A00DFD3F3 /* FeedImageDataLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
 		C5B2216A28F5D95600FC61CF /* EssentialFeed.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = EssentialFeed.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C5B2216B28F5D95600FC61CF /* EssentialFeediOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = EssentialFeediOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C5E6070628F9C8D90062DFEE /* FeedLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
@@ -170,6 +172,7 @@
 				C50D2F4128F8805E00ED7ADF /* EssentialAppTests-Bridging-Header.h */,
 				C5296BDD28F91A8D00CA7381 /* FeedImageDataLoaderWithFallbackCompositeTests.swift */,
 				C5E6070628F9C8D90062DFEE /* FeedLoaderCacheDecoratorTests.swift */,
+				C59A89C928FAC12A00DFD3F3 /* FeedImageDataLoaderCacheDecoratorTests.swift */,
 			);
 			path = EssentialAppTests;
 			sourceTree = "<group>";
@@ -330,6 +333,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C5296BE528F93A9C00CA7381 /* SharedTestHelpers.swift in Sources */,
+				C59A89CA28FAC12A00DFD3F3 /* FeedImageDataLoaderCacheDecoratorTests.swift in Sources */,
 				C5E6070B28F9D2770062DFEE /* XCTestCase+FeedLoader.swift in Sources */,
 				C5E6070728F9C8D90062DFEE /* FeedLoaderCacheDecoratorTests.swift in Sources */,
 				C5296BDE28F91A8D00CA7381 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */,

--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		C59A89C828FABBAB00DFD3F3 /* FeedLoaderCacheDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59A89C728FABBAB00DFD3F3 /* FeedLoaderCacheDecorator.swift */; };
 		C59A89CA28FAC12A00DFD3F3 /* FeedImageDataLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59A89C928FAC12A00DFD3F3 /* FeedImageDataLoaderCacheDecoratorTests.swift */; };
 		C59A89CC28FACD8E00DFD3F3 /* FeedImageDataLoaderSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59A89CB28FACD8E00DFD3F3 /* FeedImageDataLoaderSpy.swift */; };
+		C59A89CE28FACDF000DFD3F3 /* XCTestCase+FeedImageDataLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59A89CD28FACDF000DFD3F3 /* XCTestCase+FeedImageDataLoader.swift */; };
 		C5B2216C28F5D95600FC61CF /* EssentialFeed.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5B2216A28F5D95600FC61CF /* EssentialFeed.framework */; };
 		C5B2216D28F5D95600FC61CF /* EssentialFeed.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C5B2216A28F5D95600FC61CF /* EssentialFeed.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		C5B2216E28F5D95600FC61CF /* EssentialFeediOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5B2216B28F5D95600FC61CF /* EssentialFeediOS.framework */; };
@@ -84,6 +85,7 @@
 		C59A89C728FABBAB00DFD3F3 /* FeedLoaderCacheDecorator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecorator.swift; sourceTree = "<group>"; };
 		C59A89C928FAC12A00DFD3F3 /* FeedImageDataLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
 		C59A89CB28FACD8E00DFD3F3 /* FeedImageDataLoaderSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderSpy.swift; sourceTree = "<group>"; };
+		C59A89CD28FACDF000DFD3F3 /* XCTestCase+FeedImageDataLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FeedImageDataLoader.swift"; sourceTree = "<group>"; };
 		C5B2216A28F5D95600FC61CF /* EssentialFeed.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = EssentialFeed.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C5B2216B28F5D95600FC61CF /* EssentialFeediOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = EssentialFeediOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C5E6070628F9C8D90062DFEE /* FeedLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
@@ -126,6 +128,7 @@
 				C5E6070828F9CACD0062DFEE /* FeedLoaderStub.swift */,
 				C5E6070A28F9D2770062DFEE /* XCTestCase+FeedLoader.swift */,
 				C59A89CB28FACD8E00DFD3F3 /* FeedImageDataLoaderSpy.swift */,
+				C59A89CD28FACDF000DFD3F3 /* XCTestCase+FeedImageDataLoader.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -338,6 +341,7 @@
 				C5296BE528F93A9C00CA7381 /* SharedTestHelpers.swift in Sources */,
 				C59A89CA28FAC12A00DFD3F3 /* FeedImageDataLoaderCacheDecoratorTests.swift in Sources */,
 				C5E6070B28F9D2770062DFEE /* XCTestCase+FeedLoader.swift in Sources */,
+				C59A89CE28FACDF000DFD3F3 /* XCTestCase+FeedImageDataLoader.swift in Sources */,
 				C5E6070728F9C8D90062DFEE /* FeedLoaderCacheDecoratorTests.swift in Sources */,
 				C59A89CC28FACD8E00DFD3F3 /* FeedImageDataLoaderSpy.swift in Sources */,
 				C5296BDE28F91A8D00CA7381 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */,

--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		C5B2216D28F5D95600FC61CF /* EssentialFeed.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C5B2216A28F5D95600FC61CF /* EssentialFeed.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		C5B2216E28F5D95600FC61CF /* EssentialFeediOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5B2216B28F5D95600FC61CF /* EssentialFeediOS.framework */; };
 		C5B2216F28F5D95600FC61CF /* EssentialFeediOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C5B2216B28F5D95600FC61CF /* EssentialFeediOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		C5E6070728F9C8D90062DFEE /* FeedLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5E6070628F9C8D90062DFEE /* FeedLoaderCacheDecoratorTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -77,6 +78,7 @@
 		C539529328F5D6D500094060 /* EssentialAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = EssentialAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C5B2216A28F5D95600FC61CF /* EssentialFeed.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = EssentialFeed.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C5B2216B28F5D95600FC61CF /* EssentialFeediOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = EssentialFeediOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C5E6070628F9C8D90062DFEE /* FeedLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -158,6 +160,7 @@
 				C50D2F4228F8805F00ED7ADF /* FeedLoaderWithFallbackCompositeTests.swift */,
 				C50D2F4128F8805E00ED7ADF /* EssentialAppTests-Bridging-Header.h */,
 				C5296BDD28F91A8D00CA7381 /* FeedImageDataLoaderWithFallbackCompositeTests.swift */,
+				C5E6070628F9C8D90062DFEE /* FeedLoaderCacheDecoratorTests.swift */,
 			);
 			path = EssentialAppTests;
 			sourceTree = "<group>";
@@ -317,6 +320,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C5296BE528F93A9C00CA7381 /* SharedTestHelpers.swift in Sources */,
+				C5E6070728F9C8D90062DFEE /* FeedLoaderCacheDecoratorTests.swift in Sources */,
 				C5296BDE28F91A8D00CA7381 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */,
 				C50D2F4328F8805F00ED7ADF /* FeedLoaderWithFallbackCompositeTests.swift in Sources */,
 				C5296BE328F93A5C00CA7381 /* XCTestCase+MemoryLeakTracking.swift in Sources */,

--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		C5B2216F28F5D95600FC61CF /* EssentialFeediOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C5B2216B28F5D95600FC61CF /* EssentialFeediOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		C5E6070728F9C8D90062DFEE /* FeedLoaderCacheDecoratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5E6070628F9C8D90062DFEE /* FeedLoaderCacheDecoratorTests.swift */; };
 		C5E6070928F9CACD0062DFEE /* FeedLoaderStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5E6070828F9CACD0062DFEE /* FeedLoaderStub.swift */; };
+		C5E6070B28F9D2770062DFEE /* XCTestCase+FeedLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5E6070A28F9D2770062DFEE /* XCTestCase+FeedLoader.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -81,6 +82,7 @@
 		C5B2216B28F5D95600FC61CF /* EssentialFeediOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = EssentialFeediOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C5E6070628F9C8D90062DFEE /* FeedLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
 		C5E6070828F9CACD0062DFEE /* FeedLoaderStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderStub.swift; sourceTree = "<group>"; };
+		C5E6070A28F9D2770062DFEE /* XCTestCase+FeedLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FeedLoader.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -116,6 +118,7 @@
 				C5296BE228F93A5C00CA7381 /* XCTestCase+MemoryLeakTracking.swift */,
 				C5296BE428F93A9C00CA7381 /* SharedTestHelpers.swift */,
 				C5E6070828F9CACD0062DFEE /* FeedLoaderStub.swift */,
+				C5E6070A28F9D2770062DFEE /* XCTestCase+FeedLoader.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -323,6 +326,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C5296BE528F93A9C00CA7381 /* SharedTestHelpers.swift in Sources */,
+				C5E6070B28F9D2770062DFEE /* XCTestCase+FeedLoader.swift in Sources */,
 				C5E6070728F9C8D90062DFEE /* FeedLoaderCacheDecoratorTests.swift in Sources */,
 				C5296BDE28F91A8D00CA7381 /* FeedImageDataLoaderWithFallbackCompositeTests.swift in Sources */,
 				C50D2F4328F8805F00ED7ADF /* FeedLoaderWithFallbackCompositeTests.swift in Sources */,

--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		C539527E28F5D6D500094060 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C539527C28F5D6D500094060 /* Main.storyboard */; };
 		C539528028F5D6D500094060 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C539527F28F5D6D500094060 /* Assets.xcassets */; };
 		C539528328F5D6D500094060 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C539528128F5D6D500094060 /* LaunchScreen.storyboard */; };
+		C59A89C828FABBAB00DFD3F3 /* FeedLoaderCacheDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59A89C728FABBAB00DFD3F3 /* FeedLoaderCacheDecorator.swift */; };
 		C5B2216C28F5D95600FC61CF /* EssentialFeed.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5B2216A28F5D95600FC61CF /* EssentialFeed.framework */; };
 		C5B2216D28F5D95600FC61CF /* EssentialFeed.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C5B2216A28F5D95600FC61CF /* EssentialFeed.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		C5B2216E28F5D95600FC61CF /* EssentialFeediOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5B2216B28F5D95600FC61CF /* EssentialFeediOS.framework */; };
@@ -78,6 +79,7 @@
 		C539528428F5D6D500094060 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C539528928F5D6D500094060 /* EssentialAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = EssentialAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C539529328F5D6D500094060 /* EssentialAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = EssentialAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		C59A89C728FABBAB00DFD3F3 /* FeedLoaderCacheDecorator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecorator.swift; sourceTree = "<group>"; };
 		C5B2216A28F5D95600FC61CF /* EssentialFeed.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = EssentialFeed.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C5B2216B28F5D95600FC61CF /* EssentialFeediOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = EssentialFeediOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C5E6070628F9C8D90062DFEE /* FeedLoaderCacheDecoratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderCacheDecoratorTests.swift; sourceTree = "<group>"; };
@@ -155,6 +157,7 @@
 				C539528428F5D6D500094060 /* Info.plist */,
 				C5296BDB28F9195C00CA7381 /* FeedLoaderWithFallbackComposite.swift */,
 				C5296BDF28F939FB00CA7381 /* FeedImageDataLoaderWithFallbackComposite.swift */,
+				C59A89C728FABBAB00DFD3F3 /* FeedLoaderCacheDecorator.swift */,
 			);
 			path = EssentialApp;
 			sourceTree = "<group>";
@@ -316,6 +319,7 @@
 				C539527B28F5D6D500094060 /* ViewController.swift in Sources */,
 				C539527728F5D6D500094060 /* AppDelegate.swift in Sources */,
 				C5296BDC28F9195C00CA7381 /* FeedLoaderWithFallbackComposite.swift in Sources */,
+				C59A89C828FABBAB00DFD3F3 /* FeedLoaderCacheDecorator.swift in Sources */,
 				C539527928F5D6D500094060 /* SceneDelegate.swift in Sources */,
 				C5296BE028F939FB00CA7381 /* FeedImageDataLoaderWithFallbackComposite.swift in Sources */,
 			);

--- a/EssentialApp/EssentialApp/FeedImageDataLoaderCacheDecorator.swift
+++ b/EssentialApp/EssentialApp/FeedImageDataLoaderCacheDecorator.swift
@@ -20,10 +20,16 @@ public final class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
     public func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> EssentialFeed.FeedImageDataLoaderTask {
         return decoratee.loadImageData(from: url) { [weak self] result in
             completion(result.map { data in
-                self?.cache.save(data, for: url) { _ in }
+                self?.cache.saveIgnoringResult(data, for: url)
                 return data
             })
         }
     }
     
 }
+
+private extension FeedImageDataCache {
+     func saveIgnoringResult(_ data: Data, for url: URL) {
+         save(data, for: url) { _ in }
+     }
+ }

--- a/EssentialApp/EssentialApp/FeedImageDataLoaderCacheDecorator.swift
+++ b/EssentialApp/EssentialApp/FeedImageDataLoaderCacheDecorator.swift
@@ -1,0 +1,29 @@
+//
+//  FeedImageDataLoaderCacheDecorator.swift
+//  EssentialApp
+//
+//  Created by Firdavs Bagirov on 15/10/22.
+//
+
+import Foundation
+import EssentialFeed
+
+public final class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
+    private let decoratee: FeedImageDataLoader
+    private let cache: FeedImageDataCache
+    
+    public init(decoratee: FeedImageDataLoader, cache: FeedImageDataCache) {
+        self.decoratee = decoratee
+        self.cache = cache
+    }
+    
+    public func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> EssentialFeed.FeedImageDataLoaderTask {
+        return decoratee.loadImageData(from: url) { [weak self] result in
+            completion(result.map { data in
+                self?.cache.save(data, for: url) { _ in }
+                return data
+            })
+        }
+    }
+    
+}

--- a/EssentialApp/EssentialApp/FeedLoaderCacheDecorator.swift
+++ b/EssentialApp/EssentialApp/FeedLoaderCacheDecorator.swift
@@ -1,0 +1,27 @@
+//
+//  FeedLoaderCacheDecorator.swift
+//  EssentialApp
+//
+//  Created by Firdavs Bagirov on 15/10/22.
+//
+
+import EssentialFeed 
+
+public final class FeedLoaderCacheDecorator: FeedLoader {
+    private let decoratee: FeedLoader
+    private let cache: FeedCache
+    
+    public init(decoratee: FeedLoader, cache: FeedCache) {
+        self.decoratee = decoratee
+        self.cache = cache
+    }
+    
+    public func load(completion: @escaping (FeedLoader.Result) -> Void) {
+        decoratee.load { [weak self] result in
+            completion(result.map { feed in
+                self?.cache.save(feed) { _ in}
+                return feed
+            })
+        }
+    }
+}

--- a/EssentialApp/EssentialApp/FeedLoaderCacheDecorator.swift
+++ b/EssentialApp/EssentialApp/FeedLoaderCacheDecorator.swift
@@ -5,7 +5,7 @@
 //  Created by Firdavs Bagirov on 15/10/22.
 //
 
-import EssentialFeed 
+import EssentialFeed
 
 public final class FeedLoaderCacheDecorator: FeedLoader {
     private let decoratee: FeedLoader
@@ -19,9 +19,15 @@ public final class FeedLoaderCacheDecorator: FeedLoader {
     public func load(completion: @escaping (FeedLoader.Result) -> Void) {
         decoratee.load { [weak self] result in
             completion(result.map { feed in
-                self?.cache.save(feed) { _ in}
+                self?.cache.saveIgnoringResult(feed)
                 return feed
             })
         }
+    }
+}
+
+private extension FeedCache {
+    func saveIgnoringResult(_ feed: [FeedImage]) {
+        save(feed) { _ in }
     }
 }

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -36,6 +36,16 @@ class FeedImageDataLoaderCacheDecoratorTests: XCTestCase {
         XCTAssertEqual(loader.loadedURLs, [url], "Expected to load URL from loader")
     }
     
+    func test_cancelLoadImageData_cancelsLoaderTask() {
+        let url = anyURL()
+        let (sut, loader) = makeSUT()
+        
+        let task = sut.loadImageData(from: url) { _ in }
+        task.cancel()
+        
+        XCTAssertEqual(loader.cancelledURLs, [url], "Expected to cancel URL loading from loader")
+    }
+    
     // MARK: - Helpers
     
     private func makeSUT(file: StaticString = #file, line: UInt = #line) -> (sut: FeedImageDataLoader, primary: LoaderSpy) {

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -65,8 +65,8 @@ class FeedImageDataLoaderCacheDecoratorTests: XCTestCase {
     
     // MARK: - Helpers
     
-    private func makeSUT(file: StaticString = #file, line: UInt = #line) -> (sut: FeedImageDataLoader, primary: LoaderSpy) {
-        let loader = LoaderSpy()
+    private func makeSUT(file: StaticString = #file, line: UInt = #line) -> (sut: FeedImageDataLoader, primary: FeedImageDataLoaderSpy) {
+        let loader = FeedImageDataLoaderSpy()
         let sut = FeedImageDataLoaderCacheDecorator(decoratee: loader)
         trackForMemoryLeaks(loader, file: file, line: line)
         trackForMemoryLeaks(sut, file: file, line: line)
@@ -96,34 +96,4 @@ class FeedImageDataLoaderCacheDecoratorTests: XCTestCase {
         wait(for: [exp], timeout: 1.0)
     }
     
-    private class LoaderSpy: FeedImageDataLoader {
-        private var messages = [(url: URL, completion: (FeedImageDataLoader.Result) -> Void)]()
-        var loadedURLs: [URL] {
-            return messages.map { $0.url }
-        }
-        
-        var cancelledURLs = [URL]()
-        
-        private struct Task: FeedImageDataLoaderTask {
-            let callback: () -> Void
-            func cancel() {
-                callback()
-            }
-        }
-        
-        func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> EssentialFeed.FeedImageDataLoaderTask {
-            messages.append((url, completion))
-            return Task { [weak self] in
-                self?.cancelledURLs.append(url)
-            }
-        }
-        
-        func complete(with error: Error, at index: Int = 0) {
-            messages[index].completion(.failure(error))
-        }
-        
-        func completeWith(data: Data, at index: Int = 0) {
-            messages[index].completion(.success(data))
-        }
-    }
 }

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -20,7 +20,7 @@ class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
     
 }
 
-class FeedImageDataLoaderCacheDecoratorTests: XCTestCase {
+class FeedImageDataLoaderCacheDecoratorTests: XCTestCase, FeedImageDataLoaderTestCase {
     
     func test_init_doesNotLoadImageData() {
         let (_, loader) = makeSUT()
@@ -71,29 +71,6 @@ class FeedImageDataLoaderCacheDecoratorTests: XCTestCase {
         trackForMemoryLeaks(loader, file: file, line: line)
         trackForMemoryLeaks(sut, file: file, line: line)
         return (sut, loader)
-    }
-    
-    private func expect(_ sut: FeedImageDataLoader, toCompleteWith expectedResult: FeedImageDataLoader.Result, when action: () -> Void, file: StaticString = #file, line: UInt = #line) {
-        let exp = expectation(description: "Wait for load completion")
-        
-        _ = sut.loadImageData(from: anyURL()) { receivedResult in
-            switch (receivedResult, expectedResult) {
-            case let (.success(receivedFeed), .success(expectedFeed)):
-                XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
-                
-            case (.failure, .failure):
-                break
-                
-            default:
-                XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
-            }
-            
-            exp.fulfill()
-        }
-        
-        action()
-        
-        wait(for: [exp], timeout: 1.0)
     }
     
 }

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -1,0 +1,70 @@
+//
+//  FeedImageDataLoaderCacheDecoratorTests.swift
+//  EssentialAppTests
+//
+//  Created by Firdavs Bagirov on 15/10/22.
+//
+
+import XCTest
+import EssentialFeed
+
+class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
+    private let decoratee: FeedImageDataLoader
+    init(decoratee: FeedImageDataLoader) {
+        self.decoratee = decoratee
+    }
+    
+    func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> EssentialFeed.FeedImageDataLoaderTask {
+        return decoratee.loadImageData(from: url, completion: completion)
+    }
+    
+}
+
+class FeedImageDataLoaderCacheDecoratorTests: XCTestCase {
+    
+    func test_init_doesNotLoadImageData() {
+        let (_, loader) = makeSUT()
+        XCTAssertTrue(loader.loadedURLs.isEmpty, "Expected no loaded URL")
+    }
+    
+    // MARK: - Helpers
+    
+    private func makeSUT(file: StaticString = #file, line: UInt = #line) -> (sut: FeedImageDataLoader, primary: LoaderSpy) {
+        let loader = LoaderSpy()
+        let sut = FeedImageDataLoaderCacheDecorator(decoratee: loader)
+        trackForMemoryLeaks(loader, file: file, line: line)
+        trackForMemoryLeaks(sut, file: file, line: line)
+        return (sut, loader)
+    }
+    
+    private class LoaderSpy: FeedImageDataLoader {
+        private var messages = [(url: URL, completion: (FeedImageDataLoader.Result) -> Void)]()
+        var loadedURLs: [URL] {
+            return messages.map { $0.url }
+        }
+        
+        var cancelledURLs = [URL]()
+        
+        private struct Task: FeedImageDataLoaderTask {
+            let callback: () -> Void
+            func cancel() {
+                callback()
+            }
+        }
+        
+        func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> EssentialFeed.FeedImageDataLoaderTask {
+            messages.append((url, completion))
+            return Task { [weak self] in
+                self?.cancelledURLs.append(url)
+            }
+        }
+        
+        func complete(with error: Error, at index: Int = 0) {
+            messages[index].completion(.failure(error))
+        }
+        
+        func completeWith(data: Data, at index: Int = 0) {
+            messages[index].completion(.success(data))
+        }
+    }
+}

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -7,25 +7,7 @@
 
 import XCTest
 import EssentialFeed
-
-class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
-    private let decoratee: FeedImageDataLoader
-    private let cache: FeedImageDataCache
-    init(decoratee: FeedImageDataLoader, cache: FeedImageDataCache) {
-        self.decoratee = decoratee
-        self.cache = cache
-    }
-    
-    func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> EssentialFeed.FeedImageDataLoaderTask {
-        return decoratee.loadImageData(from: url) { [weak self] result in
-            completion(result.map { data in
-                self?.cache.save(data, for: url) { _ in }
-                return data
-            })
-        }
-    }
-    
-}
+import EssentialApp
 
 class FeedImageDataLoaderCacheDecoratorTests: XCTestCase, FeedImageDataLoaderTestCase {
     

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -8,12 +8,6 @@
 import XCTest
 import EssentialFeed
 
-protocol FeedImageDataCache {
-    typealias Result = Swift.Result<Void, Error>
-    
-    func save(_ data: Data, for url: URL, completion: @escaping (Result) -> Void)
-}
-
 class FeedImageDataLoaderCacheDecorator: FeedImageDataLoader {
     private let decoratee: FeedImageDataLoader
     private let cache: FeedImageDataCache

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderCacheDecoratorTests.swift
@@ -27,6 +27,15 @@ class FeedImageDataLoaderCacheDecoratorTests: XCTestCase {
         XCTAssertTrue(loader.loadedURLs.isEmpty, "Expected no loaded URL")
     }
     
+    func test_loadImageData_loadsFromLoader() {
+        let url = anyURL()
+        let (sut, loader) = makeSUT()
+        
+        _ = sut.loadImageData(from: url) { _ in }
+        
+        XCTAssertEqual(loader.loadedURLs, [url], "Expected to load URL from loader")
+    }
+    
     // MARK: - Helpers
     
     private func makeSUT(file: StaticString = #file, line: UInt = #line) -> (sut: FeedImageDataLoader, primary: LoaderSpy) {

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderWithFallbackCompositeTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderWithFallbackCompositeTests.swift
@@ -9,7 +9,7 @@ import XCTest
 import EssentialFeed
 import EssentialApp
 
-class FeedImageDataLoaderWithFallbackCompositeTests: XCTestCase {
+class FeedImageDataLoaderWithFallbackCompositeTests: XCTestCase, FeedImageDataLoaderTestCase {
     
     func test_init_doesNotLoadImageData() {
         let (_, primaryLoader, fallbackLoader) = makeSUT()
@@ -101,29 +101,6 @@ class FeedImageDataLoaderWithFallbackCompositeTests: XCTestCase {
         trackForMemoryLeaks(fallbackLoader, file: file, line: line)
         trackForMemoryLeaks(sut, file: file, line: line)
         return (sut, primaryLoader, fallbackLoader)
-    }
-    
-    private func expect(_ sut: FeedImageDataLoader, toCompleteWith expectedResult: FeedImageDataLoader.Result, when action: () -> Void, file: StaticString = #file, line: UInt = #line) {
-        let exp = expectation(description: "Wait for load completion")
-        
-        _ = sut.loadImageData(from: anyURL()) { receivedResult in
-            switch (receivedResult, expectedResult) {
-            case let (.success(receivedFeed), .success(expectedFeed)):
-                XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
-                
-            case (.failure, .failure):
-                break
-                
-            default:
-                XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
-            }
-            
-            exp.fulfill()
-        }
-        
-        action()
-        
-        wait(for: [exp], timeout: 1.0)
     }
     
 }

--- a/EssentialApp/EssentialAppTests/FeedImageDataLoaderWithFallbackCompositeTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedImageDataLoaderWithFallbackCompositeTests.swift
@@ -93,9 +93,9 @@ class FeedImageDataLoaderWithFallbackCompositeTests: XCTestCase {
     
     // MARK: - Helpers
     
-    private func makeSUT(file: StaticString = #file, line: UInt = #line) -> (sut: FeedImageDataLoader, primary: LoaderSpy, fallback: LoaderSpy) {
-        let primaryLoader = LoaderSpy()
-        let fallbackLoader = LoaderSpy()
+    private func makeSUT(file: StaticString = #file, line: UInt = #line) -> (sut: FeedImageDataLoader, primary: FeedImageDataLoaderSpy, fallback: FeedImageDataLoaderSpy) {
+        let primaryLoader = FeedImageDataLoaderSpy()
+        let fallbackLoader = FeedImageDataLoaderSpy()
         let sut = FeedImageDataLoaderWithFallbackComposite(primary: primaryLoader, fallback: fallbackLoader)
         trackForMemoryLeaks(primaryLoader, file: file, line: line)
         trackForMemoryLeaks(fallbackLoader, file: file, line: line)
@@ -126,35 +126,5 @@ class FeedImageDataLoaderWithFallbackCompositeTests: XCTestCase {
         wait(for: [exp], timeout: 1.0)
     }
     
-    private class LoaderSpy: FeedImageDataLoader {
-        private var messages = [(url: URL, completion: (FeedImageDataLoader.Result) -> Void)]()
-        var loadedURLs: [URL] {
-            return messages.map { $0.url }
-        }
-        
-        var cancelledURLs = [URL]()
-        
-        private struct Task: FeedImageDataLoaderTask {
-            let callback: () -> Void
-            func cancel() {
-                callback()
-            }
-        }
-        
-        func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> EssentialFeed.FeedImageDataLoaderTask {
-            messages.append((url, completion))
-            return Task { [weak self] in
-                self?.cancelledURLs.append(url)
-            }
-        }
-        
-        func complete(with error: Error, at index: Int = 0) {
-            messages[index].completion(.failure(error))
-        }
-        
-        func completeWith(data: Data, at index: Int = 0) {
-            messages[index].completion(.success(data))
-        }
-    }
 }
 

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -7,25 +7,7 @@
 
 import XCTest
 import EssentialFeed
-
-class FeedLoaderCacheDecorator: FeedLoader {
-    private let decoratee: FeedLoader
-    private let cache: FeedCache
-    
-    init(decoratee: FeedLoader, cache: FeedCache) {
-        self.decoratee = decoratee
-        self.cache = cache
-    }
-    
-    func load(completion: @escaping (FeedLoader.Result) -> Void) {
-        decoratee.load { [weak self] result in
-            completion(result.map { feed in
-                self?.cache.save(feed) { _ in}
-                return feed
-            })
-        }
-    }
-}
+import EssentialApp
 
 class FeedLoaderCacheDecoratorTests: XCTestCase, FeedLoaderTestCase {
     

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -25,10 +25,10 @@ class FeedLoaderCacheDecorator: FeedLoader {
     
     func load(completion: @escaping (FeedLoader.Result) -> Void) {
         decoratee.load { [weak self] result in
-            if let feed = try? result.get() {
-                self?.cache.save(feed) { _ in }
-            }
-            completion(result)
+            completion(result.map { feed in
+                self?.cache.save(feed) { _ in}
+                return feed
+            }) 
         }
     }
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -8,15 +8,26 @@
 import XCTest
 import EssentialFeed
 
+protocol FeedCache {
+    typealias Result = Swift.Result<Void, Error>
+    
+    func save(_ feed: [FeedImage], completion: @escaping (Result) -> Void)
+}
+
 class FeedLoaderCacheDecorator: FeedLoader {
     private let decoratee: FeedLoader
+    private let cache: FeedCache
     
-    init(decoratee: FeedLoader) {
+    init(decoratee: FeedLoader, cache: FeedCache) {
         self.decoratee = decoratee
+        self.cache = cache
     }
     
     func load(completion: @escaping (FeedLoader.Result) -> Void) {
-        decoratee.load(completion: completion)
+        decoratee.load { [weak self] result in
+            self?.cache.save((try? result.get()) ?? []) { _ in }
+            completion(result)
+        }
     }
 }
 
@@ -27,23 +38,44 @@ class FeedLoaderCacheDecoratorTests: XCTestCase, FeedLoaderTestCase {
         let sut = makeSUT(loaderResult: .success(feed))
         
         expect(sut, toCompleteWith: .success(feed))
-        
     }
     
     func test_load_deliversErrorOnLoaderFailure() {
         let sut = makeSUT(loaderResult: .failure(anyNSError()))
         
         expect(sut, toCompleteWith: .failure(anyNSError()))
+    }
+    
+    func test_load_cachesLoadedFeedOnLoaderSuccess() {
+        let cache = CacheSpy()
+        let feed = uniqueFeed()
+        let sut = makeSUT(loaderResult: .success(feed), cache: cache)
         
+        sut.load { _ in }
+        
+        XCTAssertEqual(cache.messages, [.save(feed)], "Expected to cache loaded feed on success")
     }
     
     // MARK: - Helpers
     
-    private func makeSUT(loaderResult: FeedLoader.Result, file: StaticString = #file, line: UInt = #line) -> FeedLoader {
+    private func makeSUT(loaderResult: FeedLoader.Result, cache: CacheSpy = .init(), file: StaticString = #file, line: UInt = #line) -> FeedLoader {
         let loader = FeedLoaderStub(result: loaderResult)
-        let sut = FeedLoaderCacheDecorator(decoratee: loader)
+        let sut = FeedLoaderCacheDecorator(decoratee: loader, cache: cache)
         trackForMemoryLeaks(loader, file: file, line: line)
         trackForMemoryLeaks(sut, file: file, line: line)
         return sut
+    }
+    
+    private class CacheSpy: FeedCache {
+        private(set) var messages = [Message]()
+        
+        enum Message: Equatable {
+            case save([FeedImage])
+        }
+        
+        func save(_ feed: [EssentialFeed.FeedImage], completion: @escaping (FeedCache.Result) -> Void) {
+            messages.append(.save(feed))
+            completion(.success(()))
+        }
     }
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -20,7 +20,7 @@ class FeedLoaderCacheDecorator: FeedLoader {
     }
 }
 
-class FeedLoaderCacheDecoratorTests: XCTestCase {
+class FeedLoaderCacheDecoratorTests: XCTestCase, FeedLoaderTestCase {
     
     func test_load_deliversFeedOnLoaderSuccess() {
         let feed = uniqueFeed()
@@ -37,27 +37,6 @@ class FeedLoaderCacheDecoratorTests: XCTestCase {
         
         expect(sut, toCompleteWith: .failure(anyNSError()))
         
-    }
-    
-    private func expect(_ sut: FeedLoader, toCompleteWith expectedResult: FeedLoader.Result, file: StaticString = #file, line: UInt = #line) {
-        let exp = expectation(description: "Wait for load completion")
-        
-        sut.load { receivedResult in
-            switch (receivedResult, expectedResult) {
-            case let (.success(receivedFeed), .success(expectedFeed)):
-                XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
-                
-            case (.failure, .failure):
-                break
-                
-            default:
-                XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
-            }
-            
-            exp.fulfill()
-        }
-        
-        wait(for: [exp], timeout: 1.0)
     }
     
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -60,8 +60,4 @@ class FeedLoaderCacheDecoratorTests: XCTestCase {
         wait(for: [exp], timeout: 1.0)
     }
     
-    private func uniqueFeed() -> [FeedImage] {
-        return [FeedImage(id: UUID(), description: "any", location: "any", url: URL(string: "http://any-url.com")!)]
-    }
-    
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -25,7 +25,9 @@ class FeedLoaderCacheDecorator: FeedLoader {
     
     func load(completion: @escaping (FeedLoader.Result) -> Void) {
         decoratee.load { [weak self] result in
-            self?.cache.save((try? result.get()) ?? []) { _ in }
+            if let feed = try? result.get() {
+                self?.cache.save(feed) { _ in }
+            }
             completion(result)
         }
     }
@@ -54,6 +56,15 @@ class FeedLoaderCacheDecoratorTests: XCTestCase, FeedLoaderTestCase {
         sut.load { _ in }
         
         XCTAssertEqual(cache.messages, [.save(feed)], "Expected to cache loaded feed on success")
+    }
+    
+    func test_load_doesNotCacheOnLoaderFailure() {
+        let cache = CacheSpy()
+        let sut = makeSUT(loaderResult: .failure(anyNSError()), cache: cache)
+        
+        sut.load { _ in }
+        
+        XCTAssertTrue(cache.messages.isEmpty, "Expected not to cache feed on load error")
     }
     
     // MARK: - Helpers

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -1,0 +1,78 @@
+//
+//  FeedLoaderCacheDecoratorTests.swift
+//  EssentialAppTests
+//
+//  Created by Firdavs Bagirov on 14/10/22.
+//
+
+import XCTest
+import EssentialFeed
+
+class FeedLoaderCacheDecorator: FeedLoader {
+    private let decoratee: FeedLoader
+    
+    init(decoratee: FeedLoader) {
+        self.decoratee = decoratee
+    }
+    
+    func load(completion: @escaping (FeedLoader.Result) -> Void) {
+        decoratee.load(completion: completion)
+    }
+}
+
+class FeedLoaderCacheDecoratorTests: XCTestCase {
+    
+    func test_load_deliversFeedOnLoaderSuccess() {
+        let feed = uniqueFeed()
+        let loader = LoaderStub(result: .success(feed))
+        let sut = FeedLoaderCacheDecorator(decoratee: loader)
+        
+        expect(sut, toCompleteWith: .success(feed))
+        
+    }
+    
+    func test_load_deliversErrorOnLoaderFailure() {
+        let loader = LoaderStub(result: .failure(anyNSError()))
+        let sut = FeedLoaderCacheDecorator(decoratee: loader)
+        
+        expect(sut, toCompleteWith: .failure(anyNSError()))
+        
+    }
+    
+    private func expect(_ sut: FeedLoader, toCompleteWith expectedResult: FeedLoader.Result, file: StaticString = #file, line: UInt = #line) {
+        let exp = expectation(description: "Wait for load completion")
+        
+        sut.load { receivedResult in
+            switch (receivedResult, expectedResult) {
+            case let (.success(receivedFeed), .success(expectedFeed)):
+                XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
+                
+            case (.failure, .failure):
+                break
+                
+            default:
+                XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
+            }
+            
+            exp.fulfill()
+        }
+        
+        wait(for: [exp], timeout: 1.0)
+    }
+    
+    private func uniqueFeed() -> [FeedImage] {
+        return [FeedImage(id: UUID(), description: "any", location: "any", url: URL(string: "http://any-url.com")!)]
+    }
+    
+    private class LoaderStub: FeedLoader {
+        private let result: FeedLoader.Result
+        
+        init(result: FeedLoader.Result) {
+            self.result = result
+        }
+        
+        func load(completion: @escaping (FeedLoader.Result) -> Void) {
+            completion(result)
+        }
+    }
+}

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -24,19 +24,26 @@ class FeedLoaderCacheDecoratorTests: XCTestCase, FeedLoaderTestCase {
     
     func test_load_deliversFeedOnLoaderSuccess() {
         let feed = uniqueFeed()
-        let loader = FeedLoaderStub(result: .success(feed))
-        let sut = FeedLoaderCacheDecorator(decoratee: loader)
+        let sut = makeSUT(loaderResult: .success(feed))
         
         expect(sut, toCompleteWith: .success(feed))
         
     }
     
     func test_load_deliversErrorOnLoaderFailure() {
-        let loader = FeedLoaderStub(result: .failure(anyNSError()))
-        let sut = FeedLoaderCacheDecorator(decoratee: loader)
+        let sut = makeSUT(loaderResult: .failure(anyNSError()))
         
         expect(sut, toCompleteWith: .failure(anyNSError()))
         
     }
     
+    // MARK: - Helpers
+    
+    private func makeSUT(loaderResult: FeedLoader.Result, file: StaticString = #file, line: UInt = #line) -> FeedLoader {
+        let loader = FeedLoaderStub(result: loaderResult)
+        let sut = FeedLoaderCacheDecorator(decoratee: loader)
+        trackForMemoryLeaks(loader, file: file, line: line)
+        trackForMemoryLeaks(sut, file: file, line: line)
+        return sut
+    }
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -24,7 +24,7 @@ class FeedLoaderCacheDecoratorTests: XCTestCase {
     
     func test_load_deliversFeedOnLoaderSuccess() {
         let feed = uniqueFeed()
-        let loader = LoaderStub(result: .success(feed))
+        let loader = FeedLoaderStub(result: .success(feed))
         let sut = FeedLoaderCacheDecorator(decoratee: loader)
         
         expect(sut, toCompleteWith: .success(feed))
@@ -32,7 +32,7 @@ class FeedLoaderCacheDecoratorTests: XCTestCase {
     }
     
     func test_load_deliversErrorOnLoaderFailure() {
-        let loader = LoaderStub(result: .failure(anyNSError()))
+        let loader = FeedLoaderStub(result: .failure(anyNSError()))
         let sut = FeedLoaderCacheDecorator(decoratee: loader)
         
         expect(sut, toCompleteWith: .failure(anyNSError()))
@@ -64,15 +64,4 @@ class FeedLoaderCacheDecoratorTests: XCTestCase {
         return [FeedImage(id: UUID(), description: "any", location: "any", url: URL(string: "http://any-url.com")!)]
     }
     
-    private class LoaderStub: FeedLoader {
-        private let result: FeedLoader.Result
-        
-        init(result: FeedLoader.Result) {
-            self.result = result
-        }
-        
-        func load(completion: @escaping (FeedLoader.Result) -> Void) {
-            completion(result)
-        }
-    }
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderCacheDecoratorTests.swift
@@ -8,12 +8,6 @@
 import XCTest
 import EssentialFeed
 
-protocol FeedCache {
-    typealias Result = Swift.Result<Void, Error>
-    
-    func save(_ feed: [FeedImage], completion: @escaping (Result) -> Void)
-}
-
 class FeedLoaderCacheDecorator: FeedLoader {
     private let decoratee: FeedLoader
     private let cache: FeedCache
@@ -28,7 +22,7 @@ class FeedLoaderCacheDecorator: FeedLoader {
             completion(result.map { feed in
                 self?.cache.save(feed) { _ in}
                 return feed
-            }) 
+            })
         }
     }
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderWithFallbackCompositeTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderWithFallbackCompositeTests.swift
@@ -34,8 +34,8 @@ class FeedLoaderWithFallbackCompositeTests: XCTestCase {
     // MARK: - Helpers
     
     private func makeSUT(primaryResult: FeedLoader.Result, fallbackResult: FeedLoader.Result, file: StaticString = #file, line: UInt = #line) -> FeedLoader {
-        let primaryLoader = LoaderStub(result: primaryResult)
-        let fallbackLoader = LoaderStub(result: fallbackResult)
+        let primaryLoader = FeedLoaderStub(result: primaryResult)
+        let fallbackLoader = FeedLoaderStub(result: fallbackResult)
         let sut = FeedLoaderWithFallbackComposite(primary: primaryLoader, fallback: fallbackLoader)
         trackForMemoryLeaks(primaryLoader, file: file, line: line)
         trackForMemoryLeaks(fallbackLoader, file: file, line: line)
@@ -66,17 +66,5 @@ class FeedLoaderWithFallbackCompositeTests: XCTestCase {
     
     private func uniqueFeed() -> [FeedImage] {
         return [FeedImage(id: UUID(), description: "any", location: "any", url: URL(string: "http://any-url.com")!)]
-    }
-    
-    private class LoaderStub: FeedLoader {
-        private let result: FeedLoader.Result
-        
-        init(result: FeedLoader.Result) {
-            self.result = result
-        }
-        
-        func load(completion: @escaping (FeedLoader.Result) -> Void) {
-            completion(result)
-        }
     }
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderWithFallbackCompositeTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderWithFallbackCompositeTests.swift
@@ -63,8 +63,4 @@ class FeedLoaderWithFallbackCompositeTests: XCTestCase {
         
         wait(for: [exp], timeout: 1.0)
     }
-    
-    private func uniqueFeed() -> [FeedImage] {
-        return [FeedImage(id: UUID(), description: "any", location: "any", url: URL(string: "http://any-url.com")!)]
-    }
 }

--- a/EssentialApp/EssentialAppTests/FeedLoaderWithFallbackCompositeTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedLoaderWithFallbackCompositeTests.swift
@@ -9,7 +9,7 @@ import XCTest
 import EssentialFeed
 import EssentialApp
 
-class FeedLoaderWithFallbackCompositeTests: XCTestCase {
+class FeedLoaderWithFallbackCompositeTests: XCTestCase, FeedLoaderTestCase {
     
     func test_load_deliversPrimaryFeedOnPrimaryLoadSuccess() {
         let primaryFeed = uniqueFeed()
@@ -43,24 +43,4 @@ class FeedLoaderWithFallbackCompositeTests: XCTestCase {
         return sut
     }
     
-    private func expect(_ sut: FeedLoader, toCompleteWith expectedResult: FeedLoader.Result, file: StaticString = #file, line: UInt = #line) {
-        let exp = expectation(description: "Wait for load completion")
-        
-        sut.load { receivedResult in
-            switch (receivedResult, expectedResult) {
-            case let (.success(receivedFeed), .success(expectedFeed)):
-                XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
-                
-            case (.failure, .failure):
-                break
-                
-            default:
-                XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
-            }
-            
-            exp.fulfill()
-        }
-        
-        wait(for: [exp], timeout: 1.0)
-    }
 }

--- a/EssentialApp/EssentialAppTests/Helpers/FeedImageDataLoaderSpy.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/FeedImageDataLoaderSpy.swift
@@ -1,0 +1,40 @@
+//
+//  FeedImageDataLoaderSpy.swift
+//  EssentialAppTests
+//
+//  Created by Firdavs Bagirov on 15/10/22.
+//
+
+import Foundation
+import EssentialFeed
+
+class FeedImageDataLoaderSpy: FeedImageDataLoader {
+    private var messages = [(url: URL, completion: (FeedImageDataLoader.Result) -> Void)]()
+    var loadedURLs: [URL] {
+        return messages.map { $0.url }
+    }
+    
+    var cancelledURLs = [URL]()
+    
+    private struct Task: FeedImageDataLoaderTask {
+        let callback: () -> Void
+        func cancel() {
+            callback()
+        }
+    }
+    
+    func loadImageData(from url: URL, completion: @escaping (FeedImageDataLoader.Result) -> Void) -> EssentialFeed.FeedImageDataLoaderTask {
+        messages.append((url, completion))
+        return Task { [weak self] in
+            self?.cancelledURLs.append(url)
+        }
+    }
+    
+    func complete(with error: Error, at index: Int = 0) {
+        messages[index].completion(.failure(error))
+    }
+    
+    func completeWith(data: Data, at index: Int = 0) {
+        messages[index].completion(.success(data))
+    }
+}

--- a/EssentialApp/EssentialAppTests/Helpers/FeedLoaderStub.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/FeedLoaderStub.swift
@@ -1,0 +1,21 @@
+//
+//  FeedLoaderStub.swift
+//  EssentialAppTests
+//
+//  Created by Firdavs Bagirov on 14/10/22.
+//
+
+import Foundation
+import EssentialFeed
+
+ class FeedLoaderStub: FeedLoader {
+    private let result: FeedLoader.Result
+    
+    init(result: FeedLoader.Result) {
+        self.result = result
+    }
+    
+    func load(completion: @escaping (FeedLoader.Result) -> Void) {
+        completion(result)
+    }
+}

--- a/EssentialApp/EssentialAppTests/Helpers/SharedTestHelpers.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/SharedTestHelpers.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import EssentialFeed
 
 func anyNSError() -> NSError {
     return NSError(domain: "any error", code: 0)
@@ -17,4 +18,8 @@ func anyURL() -> URL {
 
 func anyData() -> Data {
     return Data("any data".utf8)
+}
+
+func uniqueFeed() -> [FeedImage] {
+    return [FeedImage(id: UUID(), description: "any", location: "any", url: URL(string: "http://any-url.com")!)]
 }

--- a/EssentialApp/EssentialAppTests/Helpers/XCTestCase+FeedImageDataLoader.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/XCTestCase+FeedImageDataLoader.swift
@@ -1,0 +1,38 @@
+//
+//  XCTestCase+FeedImageDataLoader.swift
+//  EssentialAppTests
+//
+//  Created by Firdavs Bagirov on 15/10/22.
+//
+
+import XCTest
+import EssentialFeed
+
+protocol FeedImageDataLoaderTestCase: XCTestCase {}
+
+extension XCTestCase {
+    func expect(_ sut: FeedImageDataLoader, toCompleteWith expectedResult: FeedImageDataLoader.Result, when action: () -> Void, file: StaticString = #file, line: UInt = #line) {
+        let exp = expectation(description: "Wait for load completion")
+        
+        _ = sut.loadImageData(from: anyURL()) { receivedResult in
+            switch (receivedResult, expectedResult) {
+            case let (.success(receivedFeed), .success(expectedFeed)):
+                XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
+                
+            case (.failure, .failure):
+                break
+                
+            default:
+                XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
+            }
+            
+            exp.fulfill()
+        }
+        
+        action()
+        
+        wait(for: [exp], timeout: 1.0)
+    }
+}
+
+

--- a/EssentialApp/EssentialAppTests/Helpers/XCTestCase+FeedLoader.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/XCTestCase+FeedLoader.swift
@@ -1,0 +1,34 @@
+//
+//  XCTestCase+FeedLoader.swift
+//  EssentialAppTests
+//
+//  Created by Firdavs Bagirov on 14/10/22.
+//
+
+import XCTest
+import EssentialFeed
+
+protocol FeedLoaderTestCase: XCTestCase {}
+
+extension FeedLoaderTestCase {
+    func expect(_ sut: FeedLoader, toCompleteWith expectedResult: FeedLoader.Result, file: StaticString = #file, line: UInt = #line) {
+        let exp = expectation(description: "Wait for load completion")
+        
+        sut.load { receivedResult in
+            switch (receivedResult, expectedResult) {
+            case let (.success(receivedFeed), .success(expectedFeed)):
+                XCTAssertEqual(receivedFeed, expectedFeed, file: file, line: line)
+                
+            case (.failure, .failure):
+                break
+                
+            default:
+                XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
+            }
+            
+            exp.fulfill()
+        }
+        
+        wait(for: [exp], timeout: 1.0)
+    }
+}

--- a/EssentialFeed.xcodeproj/project.pbxproj
+++ b/EssentialFeed.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		C573C6AB28EB510700EBE404 /* CacheFeedImageDataUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C573C6AA28EB510700EBE404 /* CacheFeedImageDataUseCaseTests.swift */; };
 		C573C6AD28EB536900EBE404 /* CoreDataFeedImageDataStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C573C6AC28EB536900EBE404 /* CoreDataFeedImageDataStoreTests.swift */; };
 		C59A89C628FABB0D00DFD3F3 /* FeedCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59A89C528FABB0D00DFD3F3 /* FeedCache.swift */; };
+		C59A89D028FAD1A700DFD3F3 /* FeedImageDataCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59A89CF28FAD1A700DFD3F3 /* FeedImageDataCache.swift */; };
 		C59E355428AE5F9D005595E4 /* FeedImagePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59E355328AE5F9D005595E4 /* FeedImagePresenter.swift */; };
 		C59E355A28AF7D53005595E4 /* Feed.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C59E355928AF7D53005595E4 /* Feed.storyboard */; };
 		C59E355C28AF7E19005595E4 /* Feed.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C59E355B28AF7E19005595E4 /* Feed.xcassets */; };
@@ -236,6 +237,7 @@
 		C573C6AA28EB510700EBE404 /* CacheFeedImageDataUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheFeedImageDataUseCaseTests.swift; sourceTree = "<group>"; };
 		C573C6AC28EB536900EBE404 /* CoreDataFeedImageDataStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataFeedImageDataStoreTests.swift; sourceTree = "<group>"; };
 		C59A89C528FABB0D00DFD3F3 /* FeedCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedCache.swift; sourceTree = "<group>"; };
+		C59A89CF28FAD1A700DFD3F3 /* FeedImageDataCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataCache.swift; sourceTree = "<group>"; };
 		C59E355328AE5F9D005595E4 /* FeedImagePresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImagePresenter.swift; sourceTree = "<group>"; };
 		C59E355928AF7D53005595E4 /* Feed.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Feed.storyboard; sourceTree = "<group>"; };
 		C59E355B28AF7E19005595E4 /* Feed.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Feed.xcassets; sourceTree = "<group>"; };
@@ -468,6 +470,7 @@
 				84949CDA28089ADE002AFE21 /* FeedLoader.swift */,
 				C5506D1C28ACF09D00017508 /* FeedImageDataLoader.swift */,
 				C59A89C528FABB0D00DFD3F3 /* FeedCache.swift */,
+				C59A89CF28FAD1A700DFD3F3 /* FeedImageDataCache.swift */,
 			);
 			path = "Feed Feature";
 			sourceTree = "<group>";
@@ -937,6 +940,7 @@
 				840886F328155DFB00120BC8 /* FeedItemsMapper.swift in Sources */,
 				84949CD928089A87002AFE21 /* FeedItem.swift in Sources */,
 				84103C9528705EAC000DB2B9 /* FeedCachePolicy.swift in Sources */,
+				C59A89D028FAD1A700DFD3F3 /* FeedImageDataCache.swift in Sources */,
 				84B2837C2832B50000573C33 /* LocalFeedLoader.swift in Sources */,
 				C5AF821228BE5A9B005CEA26 /* FeedImageViewModel.swift in Sources */,
 				C53ECA9228C1F07B0077953C /* RemoteFeedImageDataLoader.swift in Sources */,

--- a/EssentialFeed.xcodeproj/project.pbxproj
+++ b/EssentialFeed.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 		C573C6A928EB4FFF00EBE404 /* FeedImageDataStoreSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C573C6A828EB4FFF00EBE404 /* FeedImageDataStoreSpy.swift */; };
 		C573C6AB28EB510700EBE404 /* CacheFeedImageDataUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C573C6AA28EB510700EBE404 /* CacheFeedImageDataUseCaseTests.swift */; };
 		C573C6AD28EB536900EBE404 /* CoreDataFeedImageDataStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C573C6AC28EB536900EBE404 /* CoreDataFeedImageDataStoreTests.swift */; };
+		C59A89C628FABB0D00DFD3F3 /* FeedCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59A89C528FABB0D00DFD3F3 /* FeedCache.swift */; };
 		C59E355428AE5F9D005595E4 /* FeedImagePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59E355328AE5F9D005595E4 /* FeedImagePresenter.swift */; };
 		C59E355A28AF7D53005595E4 /* Feed.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C59E355928AF7D53005595E4 /* Feed.storyboard */; };
 		C59E355C28AF7E19005595E4 /* Feed.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C59E355B28AF7E19005595E4 /* Feed.xcassets */; };
@@ -234,6 +235,7 @@
 		C573C6A828EB4FFF00EBE404 /* FeedImageDataStoreSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataStoreSpy.swift; sourceTree = "<group>"; };
 		C573C6AA28EB510700EBE404 /* CacheFeedImageDataUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheFeedImageDataUseCaseTests.swift; sourceTree = "<group>"; };
 		C573C6AC28EB536900EBE404 /* CoreDataFeedImageDataStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataFeedImageDataStoreTests.swift; sourceTree = "<group>"; };
+		C59A89C528FABB0D00DFD3F3 /* FeedCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedCache.swift; sourceTree = "<group>"; };
 		C59E355328AE5F9D005595E4 /* FeedImagePresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImagePresenter.swift; sourceTree = "<group>"; };
 		C59E355928AF7D53005595E4 /* Feed.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Feed.storyboard; sourceTree = "<group>"; };
 		C59E355B28AF7E19005595E4 /* Feed.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Feed.xcassets; sourceTree = "<group>"; };
@@ -465,6 +467,7 @@
 				84949CD828089A87002AFE21 /* FeedItem.swift */,
 				84949CDA28089ADE002AFE21 /* FeedLoader.swift */,
 				C5506D1C28ACF09D00017508 /* FeedImageDataLoader.swift */,
+				C59A89C528FABB0D00DFD3F3 /* FeedCache.swift */,
 			);
 			path = "Feed Feature";
 			sourceTree = "<group>";
@@ -929,6 +932,7 @@
 				84226E6C287C792E006EAECB /* ManagedCache.swift in Sources */,
 				C573C6A528EB4A6400EBE404 /* FeedImageDataStore.swift in Sources */,
 				C53ECA9528C203ED0077953C /* HTTPURLResponse+StatusCode.swift in Sources */,
+				C59A89C628FABB0D00DFD3F3 /* FeedCache.swift in Sources */,
 				C5BCA13128EEE9D800D83EBD /* CoreDataFeedStore+FeedImageDataLoader.swift in Sources */,
 				840886F328155DFB00120BC8 /* FeedItemsMapper.swift in Sources */,
 				84949CD928089A87002AFE21 /* FeedItem.swift in Sources */,

--- a/EssentialFeed/Feed Cache/Infrastructure/CoreData/FeedStore.xcdatamodeld/FeedStore2.xcdatamodel/contents
+++ b/EssentialFeed/Feed Cache/Infrastructure/CoreData/FeedStore.xcdatamodeld/FeedStore2.xcdatamodel/contents
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21279" systemVersion="21G83" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21279" systemVersion="21G115" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="ManagedCache" representedClassName="ManagedCache" syncable="YES">
         <attribute name="timestamp" attributeType="Date" usesScalarValueType="NO"/>
         <relationship name="feed" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="ManagedFeedImage" inverseName="cache" inverseEntity="ManagedFeedImage"/>
     </entity>
     <entity name="ManagedFeedImage" representedClassName="ManagedFeedImage" syncable="YES">
-        <attribute name="data" optional="YES" attributeType="Binary"/>
+        <attribute name="data" optional="YES" attributeType="Binary" allowsExternalBinaryDataStorage="YES"/>
         <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="imageDescription" optional="YES" attributeType="String"/>
         <attribute name="location" optional="YES" attributeType="String"/>

--- a/EssentialFeed/Feed Cache/LocalFeedImageDataLoader.swift
+++ b/EssentialFeed/Feed Cache/LocalFeedImageDataLoader.swift
@@ -15,8 +15,8 @@ public final class LocalFeedImageDataLoader {
     }
 }
 
-extension LocalFeedImageDataLoader {
-    public typealias SaveResult = Result<Void, Error>
+extension LocalFeedImageDataLoader: FeedImageDataCache {
+    public typealias SaveResult = FeedImageDataCache.Result
     
     public enum SaveError: Error {
         case failed

--- a/EssentialFeed/Feed Cache/LocalFeedLoader.swift
+++ b/EssentialFeed/Feed Cache/LocalFeedLoader.swift
@@ -18,8 +18,8 @@ public final class LocalFeedLoader {
     
 }
 
-extension LocalFeedLoader {
-    public typealias SaveResult = Result<Void, Error>
+extension LocalFeedLoader: FeedCache {
+    public typealias SaveResult = FeedCache.Result
     public func save(_ feed: [FeedImage], completion: @escaping (SaveResult) -> Void) {
         store.deleteCachedFeed { [weak self] deletionResult in
             guard let self = self else { return }

--- a/EssentialFeed/Feed Feature/FeedCache.swift
+++ b/EssentialFeed/Feed Feature/FeedCache.swift
@@ -1,0 +1,14 @@
+//
+//  FeedCache.swift
+//  EssentialFeed
+//
+//  Created by Firdavs Bagirov on 15/10/22.
+//
+
+import Foundation
+
+public protocol FeedCache {
+    typealias Result = Swift.Result<Void, Error>
+    
+    func save(_ feed: [FeedImage], completion: @escaping (Result) -> Void)
+}

--- a/EssentialFeed/Feed Feature/FeedImageDataCache.swift
+++ b/EssentialFeed/Feed Feature/FeedImageDataCache.swift
@@ -1,0 +1,14 @@
+//
+//  FeedImageDataCache.swift
+//  EssentialFeed
+//
+//  Created by Firdavs Bagirov on 15/10/22.
+//
+
+import Foundation
+
+public protocol FeedImageDataCache {
+    typealias Result = Swift.Result<Void, Error>
+    
+    func save(_ data: Data, for url: URL, completion: @escaping (Result) -> Void)
+}


### PR DESCRIPTION
Added [*]LoaderCacheDecorators responsible for decorating (intercepting) load operations and injecting the save side-effect on successful load results.

We can now use the decorators to compose the RemoteFeedLoader.loadwith the LocalFeedLoader.save operations in a simple, clean, extendable, modular, and testable way.